### PR TITLE
Use env var for admin password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+# Replace with your administrator password
+VITE_ADMIN_PASSWORD="change_me"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment variables
+
+Copy `.env.example` to `.env` and set `VITE_ADMIN_PASSWORD` with your admin
+password.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/2ae8c212-9c61-42a0-8f6e-11a435969ed0) and click on Share -> Publish.

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -21,8 +21,8 @@ const AdminPanel = () => {
   const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // Senha forte para acesso admin
-  const ADMIN_PASSWORD = "VipAccess2024!@#$";
+  // Admin password provided via environment variable
+  const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD as string;
 
   const handleLogin = () => {
     if (password === ADMIN_PASSWORD) {


### PR DESCRIPTION
## Summary
- read admin password from `VITE_ADMIN_PASSWORD`
- document new environment variable
- provide `.env.example`

## Testing
- `npm install`
- `npm run lint` *(fails: Unexpected any, no-empty-object-type, and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866fabb5dec8333965729637257ee2a