### PR TITLE
Use environment vars for credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_SUPABASE_URL=https://your-supabase-url.supabase.co
+VITE_SUPABASE_KEY=your-supabase-key
+VITE_ADMIN_PASSWORD=your-admin-password

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment variables
+
+1. Copy `.env.example` to `.env`.
+2. Fill in your Supabase URL, Supabase key and desired admin password.
+3. Keep the `.env` file local and out of version control.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/2ae8c212-9c61-42a0-8f6e-11a435969ed0) and click on Share -> Publish.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://oxybdckcmeusxcwzourw.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im94eWJkY2tjbWV1c3hjd3pvdXJ3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTE1NzA0NTIsImV4cCI6MjA2NzE0NjQ1Mn0.st3PWlzYwXzlRE5OV1UCfIMvHJEi6YPiBGMYwVoPD70";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -21,8 +21,8 @@ const AdminPanel = () => {
   const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // Senha forte para acesso admin
-  const ADMIN_PASSWORD = "VipAccess2024!@#$";
+  // Senha definida via variável de ambiente
+  const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD;
 
   const handleLogin = () => {
     if (password === ADMIN_PASSWORD) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_KEY: string;
+  readonly VITE_ADMIN_PASSWORD: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- keep secret values out of source by reading Supabase URL, key and admin password from env
- add sample `.env.example` and ignore `.env`
- document env setup in README
- type environment variables for Vite

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866faafc8288333889287632d4297fd