### PR TITLE
Switch admin auth to Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Example environment variables
-# Replace with your administrator password
+# Replace with your administrator credentials
+VITE_ADMIN_EMAIL="admin@example.com"
 VITE_ADMIN_PASSWORD="change_me"

--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ This project is built with:
 
 ## Environment variables
 
-Copy `.env.example` to `.env` and set `VITE_ADMIN_PASSWORD` with your admin
-password.
+Copy `.env.example` to `.env` and set `VITE_ADMIN_EMAIL` and
+`VITE_ADMIN_PASSWORD` with your Supabase admin user credentials. These values
+are used by the admin panel to sign in with `supabase.auth.signInWithPassword`.
+You must authenticate with these credentials before the analytics and
+configuration data can be loaded.
 
 ## How can I deploy this project?
 

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -29,22 +29,33 @@ const AdminPanel = () => {
   const [loading, setLoading] = useState(false);
   const [activeTab, setActiveTab] = useState("analytics");
 
-  // Senha corrigida
-  const ADMIN_PASSWORD = "admin123";
+  const ADMIN_EMAIL = import.meta.env.VITE_ADMIN_EMAIL as string;
 
-  const handleLogin = () => {
-    if (password === ADMIN_PASSWORD) {
+  const handleLogin = async () => {
+    try {
+      const { error } = await supabase.auth.signInWithPassword({
+        email: ADMIN_EMAIL,
+        password,
+      });
+
+      if (error) {
+        toast.error("Credenciais inválidas!");
+        setPassword("");
+        return;
+      }
+
       setIsAuthenticated(true);
       toast.success("Acesso autorizado!");
       loadAnalytics();
       loadConfigs();
-    } else {
-      toast.error("Senha incorreta!");
-      setPassword("");
+    } catch (err) {
+      toast.error("Erro ao fazer login!");
+      console.error(err);
     }
   };
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
     setIsAuthenticated(false);
     setPassword("");
     setAnalytics(null);
@@ -176,9 +187,6 @@ const AdminPanel = () => {
             >
               Entrar
             </Button>
-            <p className="text-xs text-gray-500 text-center">
-              Senha: admin123
-            </p>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- add admin email variable in `.env.example`
- sign in to Supabase in admin panel instead of using a hard-coded password
- document new variables and sign-in requirement in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68673a81bfd08333924bc87d1a53b355