### PR TITLE
Increase hero image height

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -166,7 +166,7 @@ const Index = () => {
                 src={configs.hero_image_url} 
                 alt="VIP Content" 
                 className="w-full max-w-md mx-auto rounded-2xl shadow-2xl"
-                style={{ maxHeight: '220px', objectFit: 'contain' }}
+                style={{ maxHeight: '250px', objectFit: 'contain' }}
               />
             ) : (
               <div className="max-w-md mx-auto">
@@ -174,7 +174,7 @@ const Index = () => {
                   src="/lovable-uploads/721e3e0c-8717-45de-9ad8-646bd50a5449.png" 
                   alt="OnlyFans - O Melhor do Brasil" 
                   className="w-full h-auto rounded-2xl shadow-2xl"
-                  style={{ maxHeight: '220px', objectFit: 'contain' }}
+                  style={{ maxHeight: '250px', objectFit: 'contain' }}
                 />
               </div>
             )}


### PR DESCRIPTION
## Summary
- enlarge hero image to 250px height for better visibility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686961b89d308333906a3f922a462340